### PR TITLE
Issue: Inconsistent Styling for Workshop Links on Workshops Page #100

### DIFF
--- a/content/workshops/index.html
+++ b/content/workshops/index.html
@@ -44,13 +44,13 @@ title: Workshops
     }
 </style>
 <div id="workshops">
-    <a class="active" href="https://denmark2024.honeynet.org/"><span>2024</span> Copenhagen</a>
-    <a href="https://austria2019.honeynet.org/"><span>2019</span> Innsbruck</a>
-    <a href="https://taiwan2018.honeynet.org/"><span>2018</span> Taipei</a>
-    <a href="https://canberra2017.honeynet.org/"><span>2017</span> Canberra</a>
-    <a href="https://sanantonio2016.honeynet.org/"><span>2016</span> San Antonio</a>
-    <a href="https://stavanger2015.honeynet.org/"><span>2015</span> Stavanger</a>
-    <a href="https://warsaw2014.honeynet.org/"><span>2014</span> Warsaw</a>
+    <a style="text-decoration: none;" class="active" href="https://denmark2024.honeynet.org/"><span>2024</span> Copenhagen</a>
+    <a  style="text-decoration: none;"  href="https://austria2019.honeynet.org/"><span>2019</span> Innsbruck</a>
+    <a style="text-decoration: none;"  href="https://taiwan2018.honeynet.org/"><span>2018</span> Taipei</a>
+    <a  style="text-decoration: none;" href="https://canberra2017.honeynet.org/"><span>2017</span> Canberra</a>
+    <a style="text-decoration: none;"  href="https://sanantonio2016.honeynet.org/"><span>2016</span> San Antonio</a>
+    <a style="text-decoration: none;"  href="https://stavanger2015.honeynet.org/"><span>2015</span> Stavanger</a>
+    <a style="text-decoration: none;"  href="https://warsaw2014.honeynet.org/"><span>2014</span> Warsaw</a>
     <div><span>2013</span> Dubai</div>
     <div><span>2012</span> SF Bay Area</div>
     <div><span>2011</span> Paris</div>


### PR DESCRIPTION
On the [Honeynet Workshops page](https://www.honeynet.org/workshops/), the first link (2024 Copenhagen) has a yellow background and underline, while all other links have a white background and no underline.

I removed the yellow background and also removed the underline by setting the text-decoration property to none. So that all the links started looking better, I have added a screenshot of solved problem  and code below.
![Screenshot (15)](https://github.com/user-attachments/assets/e0213ddd-c53f-4f0a-bd12-eeff49db705a)
![Screenshot (14)](https://github.com/user-attachments/assets/ef01e47c-f42e-4541-8ec0-076ecf8f6905)
