### PR TITLE
Fix Broken Analyzer Documentation Link

### DIFF
--- a/content/gsoc/gsoc-2025/ideas/IntelOwl.md
+++ b/content/gsoc/gsoc-2025/ideas/IntelOwl.md
@@ -7,7 +7,7 @@ mentor: "Matteo Lodi, Daniele Rosetti, Federico Gibertoni"
 project_type: "Improving an existing tool"
 ---
 
-Right now we have a lot of [Analyzers](https://intelowl.readthedocs.io/en/latest/Usage.html#analyzers) implemented in IntelOwl.
+Right now we have a lot of [Analyzers](https://intelowlproject.github.io/docs/IntelOwl/usage/#analyzers) implemented in IntelOwl.
 
 But they are not enough! They are one of the core parts of the application so we want to add even more of them!!!! :)
 


### PR DESCRIPTION
## Before:  
The previous link to the analyzers documentation was incorrect, leading to a **404 error**:  

### **Error Message:**  
404 Project not found
intelowl.readthedocs.io
The project you requested does not exist or may have been removed.
### **The broken link:**  
🔗 [[old_link](https://intelowl.readthedocs.io/en/latest/Usage.html#analyzers)]  

---

## After:  
The link has been updated to correctly point to the analyzer documentation:  

✅ [[new_link](https://intelowlproject.github.io/docs/IntelOwl/usage/#analyzers)]  

---

## Changes Made:  
- Replaced the broken link with the correct one.  
- Ensured the link is accessible and properly directs to the documentation.  

---

## Checklist:  
- [x] Verified the new link works correctly.  
- [x] Ensured no other broken links exist in the file.  

---

## Tagging for Review:  
@mlodic , @mhils Please review and approve this fix. 🚀  

---

Closes #106 