### PR TITLE
issue : fixing Inconsistent Styling for Workshop Links on Workshops Page #100

### DIFF
--- a/content/workshops/index.html
+++ b/content/workshops/index.html
@@ -41,18 +41,23 @@ title: Workshops
     #workshops > .active {
         background-color: var(--bs-primary);
         color: var(--bs-dark);
+        text-decoration: none;
+    }
+    #workshops > .active:hover{
+        background-color: #f0c933; 
+        text-decoration: underline;
     }
 </style>
 <div id="workshops">
     <a class="active" href="https://prague2025.honeynet.org/"><span>2025</span> Prague</a>
-    <a href="https://denmark2024.honeynet.org/"><span>2024</span> Copenhagen</a>
-    <a href="https://austria2019.honeynet.org/"><span>2019</span> Innsbruck</a>
-    <a href="https://taiwan2018.honeynet.org/"><span>2018</span> Taipei</a>
-    <a href="https://canberra2017.honeynet.org/"><span>2017</span> Canberra</a>
-    <a href="https://sanantonio2016.honeynet.org/"><span>2016</span> San Antonio</a>
-    <a href="https://stavanger2015.honeynet.org/"><span>2015</span> Stavanger</a>
-    <a href="https://warsaw2014.honeynet.org/"><span>2014</span> Warsaw</a>
-    <div><span>2013</span> Dubai</div>
-    <div><span>2012</span> SF Bay Area</div>
-    <div><span>2011</span> Paris</div>
+    <a class="active" href="https://denmark2024.honeynet.org/"><span>2024</span> Copenhagen</a>
+    <a class="active"  href="https://austria2019.honeynet.org/"><span>2019</span> Innsbruck</a>
+    <a class="active" href="https://taiwan2018.honeynet.org/"><span>2018</span> Taipei</a>
+    <a class="active" href="https://canberra2017.honeynet.org/"><span>2017</span> Canberra</a>
+    <a class="active" href="https://sanantonio2016.honeynet.org/"><span>2016</span> San Antonio</a>
+    <a class="active" href="https://stavanger2015.honeynet.org/"><span>2015</span> Stavanger</a>
+    <a class="active" href="https://warsaw2014.honeynet.org/"><span>2014</span> Warsaw</a>
+    <div class="active" ><span>2013</span> Dubai</div>
+    <div class="active" ><span>2012</span> SF Bay Area</div>
+    <div class="active" ><span>2011</span> Paris</div>
 </div>


### PR DESCRIPTION
This PR updates the styling of links on workshops page

1. Default link style

  -> Added a background color to all links.

  -> Removed the default underline.

 2. Hover state

  -> Underline appears only on hover.

  -> Background color becomes slightly lighter on hover for better visual feedback.

Why

Improves readability and consistency.

Provides a cleaner UI while still showing clear interaction feedback.